### PR TITLE
feat: テクスチャ変更ロジック(仮)

### DIFF
--- a/memo.md
+++ b/memo.md
@@ -1,0 +1,21 @@
+## commands
+
+### insert_resource
+`commands.insert_resource()`
+
+BevyのECSシステムにグローバルリソースとして登録。
+どのシステム関数からでもアクセス可能。
+
+```rust
+commands.insert_resource(TextureHandles {
+    normal: normal_texture.clone(),
+    special: special_texture.clone(),
+});
+
+```
+
+### spawn
+`commands.spawn()`
+
+新しいエンティティを作成。個々のエンティティを生成するときに使う。
+→ 今回はフィールドの床部分はマス毎に独立した状態管理を行いたいのでこれを使う


### PR DESCRIPTION
### テスクチャに関して
シンプルなものはメッシュにpngを張り付けるだけでも結構いい感じに作れそう

 現在の動作：
  - ブロックをクリックすると、そのブロックが選択され、同時にテクスチャを切り替える
  - 各ブロックは個別にテクスチャ状態を持つため、マス単位で異なるテクスチャを設定
  - ※TODO special_texture.pngなど必要なファイルはassetsフォルダに配置